### PR TITLE
Ello Button Size Selector: Style Radios

### DIFF
--- a/_assets/stylesheets/sections/_ello_button.scss
+++ b/_assets/stylesheets/sections/_ello_button.scss
@@ -5,10 +5,10 @@
     margin-bottom: $gutter_px;
     font-size: $bigText;
     line-height: $bigTextLine;
-  }
 
-  label {
-    padding: 15px;
+    &.size-choice-label {
+      margin-bottom: 1rem;
+    }
   }
 
   span,
@@ -24,12 +24,41 @@
     border: 1px solid $grey3;
   }
 
+
+  label {
+    cursor: pointer;
+    padding-right: 35px;
+  }
+  input[type=radio] {
+    display:none;
+  }
+  input[type=radio] + label span {
+    display:inline-block;
+    cursor: pointer;
+    margin: -3px 10px 0 0;
+    width: 20px;
+    height: 20px;
+    vertical-align:middle;
+    border: 1px solid $grey3;
+    @include border_radius(20px);
+    background-color: $white;
+  }
+
+  input[type=radio]:checked + label span{
+    border-color: $black;
+    background-color: $black
+  }
+
   span {
     &.label {
       &.sub {
         color: $grey3;
       }
     }
+  }
+
+  .size-choices {
+    padding-bottom: 20px;
   }
 
   .step {

--- a/_assets/stylesheets/sections/_ello_button.scss
+++ b/_assets/stylesheets/sections/_ello_button.scss
@@ -9,6 +9,11 @@
     &.size-choice-label {
       margin-bottom: 1rem;
     }
+
+    @media only screen and (max-width : 539px) {
+      font-size: 1.1rem;
+      line-height: 1.35rem;
+    }
   }
 
   span,
@@ -28,6 +33,10 @@
   label {
     cursor: pointer;
     padding-right: 35px;
+
+    @media only screen and (max-width : 539px) {
+      padding-right: 25px;
+    }
   }
   input[type=radio] {
     display:none;
@@ -42,6 +51,12 @@
     border: 1px solid $grey3;
     @include border_radius(20px);
     background-color: $white;
+
+    @media only screen and (max-width : 539px) {
+      margin: -3px 6px 0 0;
+      width: 14px;
+      height: 14px;
+    }
   }
 
   input[type=radio]:checked + label span{

--- a/_includes/ello_button.html
+++ b/_includes/ello_button.html
@@ -6,16 +6,16 @@
   </div>
   
   <div class="step two">
-    <h2>2. Select your button size and color</h2>
-    <div>
+    <h2 class="size-choice-label">2. Select your button size and color</h2>
+    <div class="size-choices">
       <input type="radio" name="size" id="small" value="small"/>
-      <label for="small">18x18</label>
+      <label for="small"><span></span>18x18</label>
 
       <input type="radio" name="size" id="medium" value="medium"/>
-      <label for="medium">24x24</label>
+      <label for="medium"><span></span>24x24</label>
 
       <input type="radio" name="size" id="large" value="large" checked="checked"/>
-      <label for="large">40x40</label>
+      <label for="large"><span></span>40x40</label>
     </div>
     <br>
     <div class="option black clear">


### PR DESCRIPTION
Styles the radio buttons for the size-selector:

![ello-radios](https://cloud.githubusercontent.com/assets/867428/13019153/eb90a428-d18a-11e5-8df9-7d02fda83aa9.gif)

**Desktop:**
<img width="899" alt="screen shot on 2016-02-12 at 13-24-49" src="https://cloud.githubusercontent.com/assets/867428/13019347/145a97f0-d18c-11e5-90d7-959abbd9ed43.png">

**Mobile:**
<img width="322" alt="screen shot on 2016-02-12 at 13-24-15" src="https://cloud.githubusercontent.com/assets/867428/13019355/19152d78-d18c-11e5-99e9-443d08fd28db.png">
